### PR TITLE
OSC ping feature

### DIFF
--- a/src/constants/AutomationPresets.ts
+++ b/src/constants/AutomationPresets.ts
@@ -27,12 +27,14 @@ export interface IAutomationProtocol {
         STATE_CHANNEL_PST: string,
         STATE_CHANNEL_FADER_LEVEL: string,
         STATE_FULL: string
+        PING: string
     },
     toAutomation: {
         STATE_CHANNEL_PGM: string,
         STATE_CHANNEL_PST: string,
         STATE_CHANNEL_FADER_LEVEL: string,
-        STATE_FULL: string
+        STATE_FULL: string,
+        PONG: string
     },
     fader: {
         min: number,
@@ -75,13 +77,15 @@ export const AutomationPresets: { [key: string]: IAutomationProtocol } = {
             STATE_CHANNEL_PGM: '/state/ch/{value1}/pgm',
             STATE_CHANNEL_PST: '/state/ch/{value1}/pst',
             STATE_CHANNEL_FADER_LEVEL: '/state/ch/{value1}/faderlevel',
-            STATE_FULL: '/state/full'
+            STATE_FULL: '/state/full',
+            PING: '/ping/{value1}'
         },
         toAutomation: {
             STATE_CHANNEL_PGM: '/state/ch/{value1}/pgm',
             STATE_CHANNEL_PST: '/state/ch/{value1}/pst',
             STATE_CHANNEL_FADER_LEVEL: '/state/ch/{value1}/faderlevel',
-            STATE_FULL: '/state/full'
+            STATE_FULL: '/state/full',
+            PONG: '/pong'
         },
         fader: {
             min: 0,

--- a/src/utils/AutomationConnection.ts
+++ b/src/utils/AutomationConnection.ts
@@ -178,6 +178,17 @@ export class AutomationConnection {
                     "f",
                     info
                 );
+            } else if (this.checkOscCommand(message.address, this.automationProtocol.fromAutomation
+                .PING)) {
+                let pingValue = message.address.split("/")[2];
+                
+                this.sendOutMessage(
+                    this.automationProtocol.toAutomation.PONG,
+                    0,
+                    pingValue,
+                    "s",
+                    info
+                )
             }
         })
         .on('error', (error: any) => {


### PR DESCRIPTION
This PR adds the functionality to let an automation system ping sisyfos, to verify connectivity status.

An OSC-command "/ping/1234" will make sisyfos return "/pong" with the same value "1234".