### PR TITLE
feat/mixer-online: ping from automation returns 'offline' if Audiomix…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ To set the state send these OSC commands from you Automation to ProducersAudioMi
 
 ## Check connectivity
 /ping/{value}
-_In response to a ping, sisyfos will reply with /pong and the provided value_
+_In response to a ping, sisyfos will reply with /pong and the provided value OR 'offline' if Audiomixer is not connected_

--- a/src/utils/AutomationConnection.ts
+++ b/src/utils/AutomationConnection.ts
@@ -259,8 +259,8 @@ export class AutomationConnection {
                 );
             } else if (this.checkOscCommand(message.address, this.automationProtocol.fromAutomation
                 .PING)) {
-                let pingValue = message.address.split("/")[2];
-
+                let pingValue = this.store.settings[0].mixerOnline ? message.address.split("/")[2] : 'offline';
+                
                 this.sendOutMessage(
                     this.automationProtocol.toAutomation.PONG,
                     0,


### PR DESCRIPTION
…er is not connected