### PR TITLE
fix: Prevent scrolling of parent when in an iframe

### DIFF
--- a/client/assets/css/App.css
+++ b/client/assets/css/App.css
@@ -5,6 +5,7 @@ body {
     font-family: sans-serif;
     background-color: black;
     user-select: none;
+    overscroll-behavior: contain;
 }
 
 .App {


### PR DESCRIPTION
This PR adds `overscroll-behavior: contain;` to the body tag, to prevent the behavior where when user scrolls the iframe contents and reaches the end, the browser will start scrolling the outer page.