### PR TITLE
fix: subscribe to VU meters upon connection

### DIFF
--- a/client/index.tsx
+++ b/client/index.tsx
@@ -57,9 +57,6 @@ socketClientHandlers()
 window.socketIoClient.emit('get-store', 'update local store')
 window.socketIoClient.emit('get-settings', 'update local settings')
 window.socketIoClient.emit('get-mixerprotocol', 'get selected mixerprotocol')
-if (!window.location.search.includes('vu=0')) {
-    window.socketIoClient.emit('subscribe-vu-meter', 'subscribe to vu meters')
-}
 
 ReactDom.render(
     <ReduxProvider store={storeRedux}>

--- a/client/utils/SocketClientHandlers.ts
+++ b/client/utils/SocketClientHandlers.ts
@@ -36,6 +36,13 @@ export const socketClientHandlers = () => {
         .on('connect', () => {
             window.storeRedux.dispatch(storeSetServerOnline(true))
             console.log('CONNECTED TO SISYFOS SERVER')
+            if (!window.location.search.includes('vu=0')) {
+                // subscribe to VU'
+                window.socketIoClient.emit(
+                    'subscribe-vu-meter',
+                    'subscribe to vu meters'
+                )
+            }
         })
         .on('disconnect', () => {
             window.storeRedux.dispatch(storeSetServerOnline(false))

--- a/server/utils/vuServer.ts
+++ b/server/utils/vuServer.ts
@@ -6,7 +6,10 @@ export enum VuType {
 const sockets: Array<any> = []
 
 export function socketSubscribeVu(socket: any) {
-    sockets.push(socket)
+    const i = sockets.indexOf(socket)
+    if (i === -1) {
+        sockets.push(socket)
+    }
 }
 
 export function socketUnsubscribeVu(socket: any) {


### PR DESCRIPTION
This PR adds a subscription request every time the client reconnects to the server. This fixes stuck metering after reconnection.