### PR TITLE
Various fixes and features

### DIFF
--- a/client/assets/css/Channel.css
+++ b/client/assets/css/Channel.css
@@ -135,7 +135,7 @@
 }
 
 .channel-pst-button.on {
-    background-color: rgb(124, 0, 0);
+    background-color: rgb(34, 135, 20);
 }
 
 .channel-pst-button.vo {

--- a/client/assets/css/Channel.css
+++ b/client/assets/css/Channel.css
@@ -232,7 +232,7 @@
     border-color: rgba(0, 0, 0);
 }
 
-.channel-volume-fader::before,
+/* .channel-volume-fader::before,
 .channel-volume-fader::after {
     content: '__';
     position: absolute;
@@ -244,7 +244,7 @@
 }
 .channel-volume-fader::after {
     right: 9px;
-}
+} */
 
 :focus {
     outline: 0;

--- a/client/assets/css/Channel.css
+++ b/client/assets/css/Channel.css
@@ -16,6 +16,10 @@
     flex-direction: column;
     align-items: center;
 }
+.channel-body > .channel-props {
+    display: flex;
+    flex-direction: column;
+}
 .channel-body > .channel-props,
 .channel-body > .out-control,
 .channel-body > .channel-control {

--- a/client/assets/css/NoUiSlider.css
+++ b/client/assets/css/NoUiSlider.css
@@ -103,7 +103,7 @@
     width: 49px;
     height: 75px;
     right: -20px;
-    top: -35px;
+    top: -38px;
 }
 .noUi-txt-dir-rtl.noUi-horizontal .noUi-handle {
     left: -17px;
@@ -300,28 +300,46 @@
 .noUi-pips-vertical {
     padding: 0 10px;
     height: 100%;
-    top: 0;
-    left: 100%;
+    top: 0px;
+    left: 0%;
 }
 .noUi-value-vertical {
     -webkit-transform: translate(0, -50%);
-    transform: translate(0, -50%);
-    padding-left: 25px;
+    transform: translate(0, -100%);
+    padding-left: 0px;
+    font-size: 10px;
 }
 .noUi-rtl .noUi-value-vertical {
     -webkit-transform: translate(0, 50%);
-    transform: translate(0, 50%);
+    transform: translate(0, 100%);
 }
 .noUi-marker-vertical.noUi-marker {
-    width: 5px;
+    width: 0px;
     height: 2px;
     margin-top: -1px;
 }
 .noUi-marker-vertical.noUi-marker-sub {
     width: 10px;
+    height: 1px;
+}
+.noUi-marker-vertical.noUi-marker-sub::before {
+    content: ' ';
+    width: 10px;
+    height: 1px;
+    position: absolute;
+    background: #aaa;
+    left: -22px;
 }
 .noUi-marker-vertical.noUi-marker-large {
     width: 15px;
+}
+.noUi-marker-vertical.noUi-marker-large::before {
+    content: ' ';
+    width: 15px;
+    height: 2px;
+    position: absolute;
+    background: #aaa;
+    left: -27px;
 }
 .noUi-tooltip {
     display: block;

--- a/client/components/Channels.tsx
+++ b/client/components/Channels.tsx
@@ -227,9 +227,9 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                     </div>
                 )}
                 {this.props.settings.showChanStripFull >= 0 ? (
-                        <ChanStripFull
-                            faderIndex={this.props.settings.showChanStripFull}
-                        />
+                    <ChanStripFull
+                        faderIndex={this.props.settings.showChanStripFull}
+                    />
                 ) : (
                     <div></div>
                 )}
@@ -285,18 +285,16 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                                 SETTINGS
                             </button>
                         )}
-                        {window.location.search.includes(
-                            'settings=0'
-                        ) ? null : (
-                            <button
-                                className="button half channels-show-storage-button"
-                                onClick={() => {
-                                    this.handleShowStorage()
-                                }}
-                            >
-                                STORAGE
-                            </button>
-                        )}
+
+                        <button
+                            className="button half channels-show-storage-button"
+                            onClick={() => {
+                                this.handleShowStorage()
+                            }}
+                        >
+                            STORAGE
+                        </button>
+
                         {window.location.search.includes(
                             'settings=0'
                         ) ? null : (
@@ -346,7 +344,9 @@ const mapStateToProps = (state: any): IChannelsInjectProps => {
         faders: state.faders[0].fader,
         customPages: state.settings[0].customPages,
         settings: state.settings[0],
-        mixersOnline: state.settings[0].mixers.map((m: IMixerSettings) => m.mixerOnline).reduce((a: boolean, b: boolean) => a && b)
+        mixersOnline: state.settings[0].mixers
+            .map((m: IMixerSettings) => m.mixerOnline)
+            .reduce((a: boolean, b: boolean) => a && b),
     }
 }
 

--- a/client/components/Channels.tsx
+++ b/client/components/Channels.tsx
@@ -19,6 +19,7 @@ import { IChannels } from '../../server/reducers/channelsReducer'
 import { IFader } from '../../server/reducers/fadersReducer'
 import {
     ICustomPages,
+    IMixerSettings,
     ISettings,
     PageType,
 } from '../../server/reducers/settingsReducer'
@@ -35,6 +36,7 @@ interface IChannelsInjectProps {
     faders: IFader[]
     settings: ISettings
     customPages: ICustomPages[]
+    mixersOnline: boolean
 }
 
 class Channels extends React.Component<IChannelsInjectProps & Store> {
@@ -55,8 +57,7 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                 nextProps.settings.showMonitorOptions ||
             this.props.settings.customPages !==
                 nextProps.settings.customPages ||
-            this.props.settings.mixers[0].mixerOnline !==
-                nextProps.settings.mixers[0].mixerOnline ||
+            this.props.mixersOnline !== nextProps.mixersOnline ||
             this.props.faders.length !== nextProps.faders.length ||
             this.props.settings.currentPage !==
                 nextProps.settings.currentPage ||
@@ -242,13 +243,12 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                 <br />
                 <div className="channels-mix-body">
                     <div className="top">
-                        {this.props.settings.mixers[0].mixerOnline ? (
+                        {this.props.mixersOnline ? (
                             <button
                                 className={ClassNames(
                                     'button half channels-show-mixer-online',
                                     {
-                                        connected: this.props.settings.mixers[0]
-                                            .mixerOnline,
+                                        connected: this.props.mixersOnline,
                                     }
                                 )}
                                 onClick={() => {
@@ -262,8 +262,7 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                                 className={ClassNames(
                                     'button half channels-show-mixer-online',
                                     {
-                                        connected: this.props.settings.mixers[0]
-                                            .mixerOnline,
+                                        connected: this.props.mixersOnline,
                                     }
                                 )}
                                 onClick={() => {
@@ -347,6 +346,7 @@ const mapStateToProps = (state: any): IChannelsInjectProps => {
         faders: state.faders[0].fader,
         customPages: state.settings[0].customPages,
         settings: state.settings[0],
+        mixersOnline: state.settings[0].mixers.map((m: IMixerSettings) => m.mixerOnline).reduce((a: boolean, b: boolean) => a && b)
     }
 }
 

--- a/client/utils/SocketClientHandlers.ts
+++ b/client/utils/SocketClientHandlers.ts
@@ -28,6 +28,7 @@ import {
     InumberOfChannels,
 } from '../../server/reducers/channelsReducer'
 import { VuType } from '../../server/utils/vuServer'
+import { IMixerSettings } from '../../server/reducers/settingsReducer'
 
 export const vuMeters: number[][] = []
 
@@ -72,10 +73,12 @@ export const socketClientHandlers = () => {
                         payload.settings[0].numberOfFaders
                     )
                 )
-                window.storeRedux.dispatch(
-                    storeSetMixerOnline(
-                        payload.settings[0].mixers[0].mixerOnline
-                    )
+                payload.settings[0].mixers.forEach(
+                    (mixer: IMixerSettings, i: number) => {
+                        window.storeRedux.dispatch(
+                            storeSetMixerOnline(i, mixer.mixerOnline)
+                        )
+                    }
                 )
                 window.storeRedux.dispatch(storeSetServerOnline(true))
             }
@@ -91,7 +94,9 @@ export const socketClientHandlers = () => {
             window.mixerProtocolList = payload.mixerProtocolList
         })
         .on(SOCKET_SET_MIXER_ONLINE, (payload: any) => {
-            window.storeRedux.dispatch(storeSetMixerOnline(payload.mixerOnline))
+            window.storeRedux.dispatch(
+                storeSetMixerOnline(payload.mixerIndex, payload.mixerOnline)
+            )
         })
         .on(SOCKET_SET_STORE_FADER, (payload: any) => {
             window.storeRedux.dispatch(

--- a/server/constants/MixerProtocolInterface.ts
+++ b/server/constants/MixerProtocolInterface.ts
@@ -20,6 +20,12 @@ export enum fxParamsList {
     CompHold,
     CompRelease,
 }
+export enum VuLabelConversionType {
+    Linear = 'linear',
+    Decibel = 'decibel',
+    DecibelRuby = 'decibelRuby',
+    DecibelMC2 = 'decibelMC2',
+}
 export interface IMixerProtocolGeneric {
     protocol: string
     fxList?: {}
@@ -27,6 +33,8 @@ export interface IMixerProtocolGeneric {
     presetFileExtension?: string
     loadPresetCommand?: Array<IMixerMessageProtocol>
     FADE_DISPATCH_RESOLUTION: number
+    vuLabelConversionType?: VuLabelConversionType
+    vuLabelValues?: Array<number>
     fader?: {
         min: number
         max: number

--- a/server/constants/mixerProtocols/LawoMC2.ts
+++ b/server/constants/mixerProtocols/LawoMC2.ts
@@ -3,8 +3,12 @@ import { IMixerProtocol, emptyMixerMessage } from '../MixerProtocolInterface'
 export const LawoMC2: IMixerProtocol = {
     protocol: 'EMBER',
     label: 'Lawo MC2',
-    presetFileExtension: '',
-    loadPresetCommand: [emptyMixerMessage()],
+    presetFileExtension: 'MC2',
+    loadPresetCommand: [
+        {
+            mixerMessage: 'Production.Load Snapshot',
+        },
+    ],
     FADE_DISPATCH_RESOLUTION: 5,
     leadingZeros: false, //some OSC protocols needs channels to be 01, 02 etc.
     pingCommand: [emptyMixerMessage()],

--- a/server/constants/mixerProtocols/LawoMC2.ts
+++ b/server/constants/mixerProtocols/LawoMC2.ts
@@ -47,6 +47,8 @@ export const LawoMC2: IMixerProtocol = {
                         min: -128,
                         max: 12,
                         zero: 0,
+                        maxLabel: 12,
+                        minLabel: -128,
                     },
                 ],
                 CHANNEL_INPUT_SELECTOR: [
@@ -109,12 +111,14 @@ export const LawoMC2: IMixerProtocol = {
                 CHANNEL_INPUT_GAIN: [
                     {
                         mixerMessage:
-                            'Channels.Inputs.${channel}.Signal Processing.Input Mixer.Input Gain',
+                            'Channels.Inputs.${channel}.Signal Processing.Digital Amplifier.DigiAmp Level',
                         value: 0,
                         type: 'int',
                         min: -128,
                         max: 12,
                         zero: 0,
+                        maxLabel: 12,
+                        minLabel: -128,
                     },
                 ],
                 CHANNEL_INPUT_SELECTOR: [

--- a/server/constants/mixerProtocols/LawoMC2.ts
+++ b/server/constants/mixerProtocols/LawoMC2.ts
@@ -1,4 +1,8 @@
-import { IMixerProtocol, emptyMixerMessage } from '../MixerProtocolInterface'
+import {
+    IMixerProtocol,
+    emptyMixerMessage,
+    VuLabelConversionType,
+} from '../MixerProtocolInterface'
 
 export const LawoMC2: IMixerProtocol = {
     protocol: 'EMBER',
@@ -15,6 +19,8 @@ export const LawoMC2: IMixerProtocol = {
     pingResponseCommand: [emptyMixerMessage()],
     pingTime: 0, //Bypass ping when pingTime is zero
     initializeCommands: [emptyMixerMessage()],
+    vuLabelConversionType: VuLabelConversionType.DecibelMC2,
+    vuLabelValues: [0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1],
     channelTypes: [
         {
             channelTypeName: 'CH',

--- a/server/constants/mixerProtocols/LawoMC2.ts
+++ b/server/constants/mixerProtocols/LawoMC2.ts
@@ -41,7 +41,7 @@ export const LawoMC2: IMixerProtocol = {
                 CHANNEL_INPUT_GAIN: [
                     {
                         mixerMessage:
-                            'Channels.Inputs.${channel}.Signal Processing.Input Mixer.Input Gain',
+                            'Channels.Inputs.${channel}.Signal Processing.Digital Amplifier.DigiAmp Level',
                         value: 0,
                         type: 'int',
                         min: -128,

--- a/server/constants/mixerProtocols/LawoRuby.ts
+++ b/server/constants/mixerProtocols/LawoRuby.ts
@@ -1,4 +1,8 @@
-import { IMixerProtocol, emptyMixerMessage } from '../MixerProtocolInterface'
+import {
+    IMixerProtocol,
+    emptyMixerMessage,
+    VuLabelConversionType,
+} from '../MixerProtocolInterface'
 
 export const LawoRuby: IMixerProtocol = {
     protocol: 'LAWORUBY',
@@ -11,6 +15,8 @@ export const LawoRuby: IMixerProtocol = {
     pingResponseCommand: [emptyMixerMessage()],
     pingTime: 0, //Bypass ping when pingTime is zero
     initializeCommands: [emptyMixerMessage()],
+    vuLabelConversionType: VuLabelConversionType.Decibel,
+    vuLabelValues: [0, 0.5, 0.75, 1],
     channelTypes: [
         {
             channelTypeName: 'CH',

--- a/server/reducers/settingsActions.ts
+++ b/server/reducers/settingsActions.ts
@@ -65,9 +65,13 @@ export const storeUpdatePagesList = (customPages: ICustomPages[]) => {
         customPages: customPages,
     }
 }
-export const storeSetMixerOnline = (mixerOnline: boolean) => {
+export const storeSetMixerOnline = (
+    mixerIndex: number,
+    mixerOnline: boolean
+) => {
     return {
         type: SET_MIXER_ONLINE,
+        mixerIndex: mixerIndex,
         mixerOnline: mixerOnline,
     }
 }

--- a/server/reducers/settingsReducer.ts
+++ b/server/reducers/settingsReducer.ts
@@ -187,7 +187,8 @@ export const settings = (
             nextState[0].customPages = action.customPages
             return nextState
         case SET_MIXER_ONLINE:
-            nextState[0].mixers[0].mixerOnline = action.mixerOnline
+            nextState[0].mixers[action.mixerIndex || 0].mixerOnline =
+                action.mixerOnline
             return nextState
         case SET_SERVER_ONLINE:
             nextState[0].serverOnline = action.serverOnline

--- a/server/utils/dbConversion.ts
+++ b/server/utils/dbConversion.ts
@@ -1,0 +1,46 @@
+import { VuLabelConversionType } from '../constants/MixerProtocolInterface'
+
+export const Conversions = {
+    [VuLabelConversionType.Decibel]: {
+        to: (f: number): number => {
+            if (f >= 0.5) {
+                return f * 40 - 30 // max dB value: +10.
+            } else if (f >= 0.25) {
+                return f * 80 - 50
+            } else if (f >= 0.0625) {
+                return f * 160 - 70
+            } else if (f > 0.0) {
+                return f * 480 - 90 // min dB value: -90 or -oo
+            } else {
+                return -Infinity
+            }
+        },
+        from: (d: number): number => {
+            let f: number
+            if (d < -60) {
+                f = (d + 90) / 480
+            } else if (d < -30) {
+                f = (d + 70) / 160
+            } else if (d < -10) {
+                f = (d + 50) / 80
+            } else if (d <= 10) {
+                f = (d + 30) / 40
+            } else {
+                f = 1
+            }
+            return Math.max(0, f)
+        },
+    },
+    [VuLabelConversionType.DecibelRuby]: {
+        to: (f: number): number =>
+            Math.max(Conversions[VuLabelConversionType.Decibel].to(f), -191),
+        from: (d: number): number =>
+            Conversions[VuLabelConversionType.Decibel].from(d),
+    },
+    [VuLabelConversionType.DecibelMC2]: {
+        to: (f: number): number =>
+            Math.max(Conversions[VuLabelConversionType.Decibel].to(f), -128),
+        from: (d: number): number =>
+            Conversions[VuLabelConversionType.Decibel].from(d),
+    },
+}

--- a/server/utils/mixerConnections/EmberMixerConnection.ts
+++ b/server/utils/mixerConnections/EmberMixerConnection.ts
@@ -364,7 +364,7 @@ export class EmberMixerConnection {
                 store.dispatch(
                     storeSetPfl(
                         channel.assignedFader,
-                        (node.contents as Model.Parameter).value !== 0
+                        (node.contents as Model.Parameter).value as boolean
                     )
                 )
                 global.mainThreadHandler.updatePartialStore(
@@ -481,8 +481,11 @@ export class EmberMixerConnection {
                     storeCapability(
                         channel.assignedFader,
                         'hasInputSelector',
-                        (node.contents as Model.Parameter).value === 1
+                        (node.contents as Model.Parameter).value as boolean
                     )
+                )
+                global.mainThreadHandler.updatePartialStore(
+                    channel.assignedFader
                 )
             }
         )
@@ -561,7 +564,9 @@ export class EmberMixerConnection {
                         storeCapability(
                             channel.assignedFader,
                             'hasAMix',
-                            (node.contents as Model.Parameter).value !== 15 // 15 is no unassigned
+                            (node.contents as Model.Parameter).value !==
+                                ((node.contents as Model.Parameter).maximum ||
+                                    63) // max is unassigned, max = 63 in firmware 6.4
                         )
                     )
                     global.mainThreadHandler.updatePartialStore(
@@ -585,7 +590,7 @@ export class EmberMixerConnection {
                 store.dispatch(
                     storeSetAMix(
                         channel.assignedFader,
-                        (node.contents as Model.Parameter).value === 1
+                        (node.contents as Model.Parameter).value as boolean
                     )
                 )
                 global.mainThreadHandler.updatePartialStore(

--- a/server/utils/mixerConnections/EmberMixerConnection.ts
+++ b/server/utils/mixerConnections/EmberMixerConnection.ts
@@ -404,7 +404,6 @@ export class EmberMixerConnection {
 
                 // assume it is in db now
                 level = this._faderLevelToFloat(Number(level), 0)
-
                 store.dispatch(storeInputGain(channel.assignedFader, level))
                 global.mainThreadHandler.updatePartialStore(
                     channel.assignedFader
@@ -766,7 +765,9 @@ export class EmberMixerConnection {
         let protocol = this.mixerProtocol.channelTypes[channelType].toMixer
             .CHANNEL_INPUT_GAIN[0]
 
-        let level = gain * (protocol.max - protocol.min) + protocol.min
+        let level = this._floatToFaderLevel(gain, 0)
+
+        // let level = gain * (protocol.max - protocol.min) + protocol.min
 
         this.sendOutMessage(
             protocol.mixerMessage,

--- a/server/utils/mixerConnections/EmberMixerConnection.ts
+++ b/server/utils/mixerConnections/EmberMixerConnection.ts
@@ -1,6 +1,8 @@
 import { EmberClient, Model, Types } from 'emberplus-connection'
 import { store, state } from '../../reducers/store'
 import { remoteConnections } from '../../mainClasses'
+import path from 'path'
+import fs from 'fs'
 
 //Utils:
 import {
@@ -890,7 +892,25 @@ export class EmberMixerConnection {
         )
     }
 
-    loadMixerPreset(presetName: string) {}
+    async loadMixerPreset(presetName: string) {
+        logger.info('Loading preset : ' + presetName)
+        if (this.mixerProtocol.presetFileExtension === 'MC2') {
+            let data = JSON.parse(
+                fs.readFileSync(path.resolve('storage', presetName)).toString()
+            )
+
+            const loadFunction = await this.emberConnection.getElementByPath(
+                this.mixerProtocol.loadPresetCommand[0].mixerMessage
+            )
+
+            if (loadFunction.contents.type === Model.ElementType.Function) {
+                this.emberConnection.invoke(
+                    loadFunction as any,
+                    data.sceneAddress
+                )
+            }
+        }
+    }
 
     injectCommand(command: string[]) {
         return true

--- a/server/utils/mixerConnections/LawoRubyConnection.ts
+++ b/server/utils/mixerConnections/LawoRubyConnection.ts
@@ -69,7 +69,7 @@ export class LawoRubyMixerConnection {
             state.settings[0].mixers[this.mixerIndex].devicePort
         )
 
-        store.dispatch(storeSetMixerOnline(false))
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
 
         this.emberConnection.on('error', (error: any) => {
             if (
@@ -83,11 +83,11 @@ export class LawoRubyMixerConnection {
         })
         this.emberConnection.on('disconnected', () => {
             logger.error('Lost Ember connection')
-            store.dispatch(storeSetMixerOnline(false))
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
         })
         this.emberConnection.on('connected', () => {
             logger.info('Connected to Ember device')
-            store.dispatch(storeSetMixerOnline(true))
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, true))
         })
 
         logger.info('Connecting to Ember')

--- a/server/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/utils/mixerConnections/OscMixerConnection.ts
@@ -45,7 +45,7 @@ export class OscMixerConnection {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
-        store.dispatch(storeSetMixerOnline(false))
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
 
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
@@ -72,8 +72,9 @@ export class OscMixerConnection {
     }
 
     mixerOnline(onLineState: boolean) {
-        store.dispatch(storeSetMixerOnline(onLineState))
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, onLineState))
         socketServer.emit(SOCKET_SET_MIXER_ONLINE, {
+            mixerIndex: this.mixerIndex,
             mixerOnline: state,
         })
     }
@@ -411,7 +412,7 @@ export class OscMixerConnection {
         })
         global.mainThreadHandler.updateFullClientStore()
         this.mixerOnlineTimer = setTimeout(() => {
-            store.dispatch(storeSetMixerOnline(false))
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
         }, this.mixerProtocol.pingTime)
     }
 

--- a/server/utils/mixerConnections/SSLMixerConnection.ts
+++ b/server/utils/mixerConnections/SSLMixerConnection.ts
@@ -27,7 +27,7 @@ export class SSLMixerConnection {
     constructor(mixerProtocol: IMixerProtocol, mixerIndex: number) {
         this.sendOutLevelMessage = this.sendOutLevelMessage.bind(this)
 
-        store.dispatch(storeSetMixerOnline(false))
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
 
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
@@ -61,7 +61,7 @@ export class SSLMixerConnection {
         let lastWasAck = false
 
         this.SSLConnection.on('ready', () => {
-            store.dispatch(storeSetMixerOnline(true))
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, true))
 
             logger.info('Receiving state of desk', {})
             this.mixerProtocol.initializeCommands.map((item) => {
@@ -79,7 +79,7 @@ export class SSLMixerConnection {
         })
             .on('data', (data: any) => {
                 clearTimeout(this.mixerOnlineTimer)
-                store.dispatch(storeSetMixerOnline(true))
+                store.dispatch(storeSetMixerOnline(this.mixerIndex, true))
 
                 let buffers = []
                 let lastIndex = 0
@@ -289,7 +289,7 @@ export class SSLMixerConnection {
         })
         global.mainThreadHandler.updateFullClientStore()
         this.mixerOnlineTimer = setTimeout(() => {
-            store.dispatch(storeSetMixerOnline(false))
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
         }, this.mixerProtocol.pingTime)
     }
 

--- a/server/utils/mixerConnections/StuderVistaMixerConnection.ts
+++ b/server/utils/mixerConnections/StuderVistaMixerConnection.ts
@@ -351,8 +351,9 @@ export class StuderVistaMixerConnection {
     }
 
     mixerOnline(onLineState: boolean) {
-        store.dispatch(storeSetMixerOnline(onLineState))
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, onLineState))
         socketServer.emit(SOCKET_SET_MIXER_ONLINE, {
+            mixerIndex: this.mixerIndex,
             mixerOnline: state,
         })
     }

--- a/server/utils/mixerConnections/YamahaQlClConnection.ts
+++ b/server/utils/mixerConnections/YamahaQlClConnection.ts
@@ -29,7 +29,7 @@ export class QlClMixerConnection {
         this.sendOutMessage = this.sendOutMessage.bind(this)
         this.pingMixerCommand = this.pingMixerCommand.bind(this)
 
-        store.dispatch(storeSetMixerOnline(false))
+        store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
 
         this.mixerProtocol = mixerProtocol
         this.mixerIndex = mixerIndex
@@ -78,7 +78,7 @@ export class QlClMixerConnection {
             })
             .on('data', (data: any) => {
                 clearTimeout(this.mixerOnlineTimer)
-                store.dispatch(storeSetMixerOnline(true))
+                store.dispatch(storeSetMixerOnline(this.mixerIndex, true))
 
                 let buffers = []
                 let lastIndex = 0
@@ -239,7 +239,7 @@ export class QlClMixerConnection {
 
     pingMixerCommand() {
         this.mixerOnlineTimer = setTimeout(() => {
-            store.dispatch(storeSetMixerOnline(false))
+            store.dispatch(storeSetMixerOnline(this.mixerIndex, false))
         }, this.mixerProtocol.pingTime)
     }
 


### PR DESCRIPTION
This PR contains various features and fixes we did while deploying a gallery for NRK.

- feat: show dB labels next to the fader if the mixer protocol supports it
- feat: ember+ snapshots from the mixer
- fix: mc2 gets boolean from ember+, not numbers
- fix: layout when there's less faders than screen width
- changed the mc2 input gain parameter
- fix: mixer status (was not updated before)
- fix: show storage button when settings are disabled
- change the color of the PFL button to green