### PR TITLE
Feature: label system

### DIFF
--- a/client/assets/css/LabelSettings.css
+++ b/client/assets/css/LabelSettings.css
@@ -1,0 +1,102 @@
+.label-settings-body {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 600px;
+    overflow: auto;
+    max-height: 90vh;
+    background-color: rgb(31, 31, 31);
+    border-color: rgb(124, 124, 124);
+    border-style: solid;
+    border-width: 4px;
+    text-align: center;
+    align-items: center;
+    z-index: 2;
+
+    color: #fff;
+}
+
+.label-settings-body > h2 {
+    border-bottom: 1px solid #999;
+    margin: 0;
+    padding: 10px 0;
+    line-height: 50px;
+    text-align: center;
+}
+
+.pages-settings-mixer-name {
+    font-size: 150%;
+    border-bottom: 1px solid #999;
+    margin: 0;
+    padding: 10px 0;
+    line-height: 50px;
+    text-align: center;
+}
+
+.pages-settings-text {
+    color: dimgray;
+    margin: 0;
+    margin-left: 40px;
+    padding: 0px 0;
+    line-height: 20px;
+    text-align: right;
+    font-size: 110%;
+}
+
+.pages-settings-tick {
+    color: dimgray;
+    margin: 0;
+    margin-right: 70px;
+    padding: 0px 0;
+    line-height: 20px;
+    text-align: right;
+    align-content: right;
+    font-size: 110%;
+}
+
+.pages-settings.checked {
+    font-weight: bold;
+    color: white;
+}
+
+.label-settings-body > .close {
+    position: absolute;
+    outline: none;
+    border-color: rgb(99, 99, 99);
+    background-color: rgb(27, 27, 27);
+    border-radius: 100%;
+    display: block;
+    color: #fff;
+    width: 50px;
+    height: 50px;
+    font-size: 30px;
+    line-height: 50px;
+    top: -5px;
+    right: 9px;
+}
+
+.label-settings-body > .button {
+    line-height: 20px;
+    outline: none;
+    border-color: rgb(99, 99, 99);
+    background-color: rgb(58, 3, 3);
+    margin-top: 15px;
+    margin-bottom: 15px;
+    border-radius: 7px;
+    color: #fff;
+    width: 34%;
+    height: 50px;
+    font-size: 10px;
+}
+
+.label-settings-body > .inputfield {
+    line-height: 40px;
+    outline: none;
+    margin-top: 45px;
+    border-radius: 7px;
+    color: #fff;
+    width: 34%;
+    height: 50px;
+    font-size: 18px;
+}

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -10,6 +10,7 @@ import Storage from './RoutingStorage'
 import MiniChannels from './MiniChannels'
 import { withTranslation } from 'react-i18next'
 import PagesSettings from './PagesSettings'
+import LabelSettings from './Labels'
 
 export interface IAppProps {
     store: IStore
@@ -40,8 +41,10 @@ class App extends React.Component<IAppProps> {
         return (
             nextProps.store.settings[0].showSettings !=
                 this.props.store.settings[0].showSettings ||
-                nextProps.store.settings[0].showPagesSetup !=
+            nextProps.store.settings[0].showPagesSetup !=
                 this.props.store.settings[0].showPagesSetup ||
+            nextProps.store.settings[0].showLabelSettings !=
+                this.props.store.settings[0].showLabelSettings ||
             nextProps.store.settings[0].serverOnline !=
                 this.props.store.settings[0].serverOnline ||
             nextProps.store.settings[0].showStorage !=
@@ -117,6 +120,7 @@ class App extends React.Component<IAppProps> {
                 {window.location.search.includes('minimonitor=1') && (
                     <MiniChannels />
                 )}
+                {this.props.store.settings[0].showLabelSettings && <LabelSettings />}
                 {this.props.store.settings[0].showPagesSetup && <PagesSettings />}
                 {this.props.store.settings[0].showStorage && <Storage />}
                 {this.props.store.settings[0].showSettings && <Settings />}

--- a/client/components/ChanStrip.tsx
+++ b/client/components/ChanStrip.tsx
@@ -20,6 +20,7 @@ import {
 import ReductionMeter from './ReductionMeter'
 import ClassNames from 'classnames'
 import { fxParamsList } from '../../server/constants/MixerProtocolInterface'
+import { getFaderLabel } from '../utils/labels'
 
 interface IChanStripInjectProps {
     label: string
@@ -277,14 +278,7 @@ class ChanStrip extends React.PureComponent<
     monitor(channelIndex: number) {
         let faderIndex = this.props.channel[channelIndex].assignedFader
         if (faderIndex === -1) return null
-        let monitorName = this.props.fader[faderIndex]
-            ? this.props.fader[faderIndex].label
-            : ''
-        if (monitorName === '') {
-            monitorName =
-                'Fader ' +
-                String(this.props.channel[channelIndex].assignedFader + 1)
-        }
+        let monitorName = getFaderLabel(faderIndex, 'Fader')
         return (
             <li key={channelIndex}>
                 {monitorName}
@@ -459,8 +453,7 @@ class ChanStrip extends React.PureComponent<
                         <React.Fragment>
                             <hr />
                             <div className="group-text">
-                                {this.props.label ||
-                                    'FADER ' + (this.props.faderIndex + 1)}
+                                {this.props.label}
                                 {' - MONITOR MIX MINUS'}
                             </div>
                             <ul className="monitor-sends">
@@ -490,8 +483,7 @@ class ChanStrip extends React.PureComponent<
             return (
                 <div className="chan-strip-body">
                     <div className="header">
-                        {this.props.label ||
-                            'FADER ' + (this.props.faderIndex + 1)}
+                        {this.props.label}
                         <button
                             className="close"
                             onClick={() => this.handleClose()}
@@ -528,7 +520,7 @@ const mapStateToProps = (state: any, props: any): IChanStripInjectProps => {
     }
     if (props.faderIndex >= 0) {
         inject = {
-            label: state.faders[0].fader[props.faderIndex].label,
+            label: getFaderLabel(props.faderIndex, 'FADER'),
             selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
             numberOfChannelsInType:
                 state.settings[0].mixers[0].numberOfChannelsInType,

--- a/client/components/ChanStripFull.tsx
+++ b/client/components/ChanStripFull.tsx
@@ -21,6 +21,7 @@ import ReductionMeter from './ReductionMeter'
 import ClassNames from 'classnames'
 import { fxParamsList } from '../../server/constants/MixerProtocolInterface'
 import { IChannel } from '../../server/reducers/channelsReducer'
+import { getFaderLabel } from '../utils/labels'
 
 interface IChanStripFullInjectProps {
     label: string
@@ -634,14 +635,7 @@ class ChanStripFull extends React.PureComponent<
     monitor(channelIndex: number) {
         let faderIndex = this.props.channel[channelIndex].assignedFader
         if (faderIndex === -1) return null
-        let monitorName = this.props.fader[faderIndex]
-            ? this.props.fader[faderIndex].label
-            : ''
-        if (monitorName === '') {
-            monitorName =
-                'Fader ' +
-                String(this.props.channel[channelIndex].assignedFader + 1)
-        }
+        let monitorName = getFaderLabel(faderIndex, 'Fader')
         return (
             <li key={channelIndex}>
                 {monitorName}
@@ -751,8 +745,7 @@ class ChanStripFull extends React.PureComponent<
                             )}
                             <div className="item">
                                 <div className="title">
-                                    {this.props.label ||
-                                        'FADER ' + (this.props.faderIndex + 1)}
+                                    {this.props.label}
                                     {' - MONITOR MIX MINUS'}
                                 </div>
                                 <div className="content">
@@ -793,8 +786,7 @@ class ChanStripFull extends React.PureComponent<
             return (
                 <div className="chan-strip-full-body">
                     <div className="ch-strip-full-header">
-                        {this.props.label ||
-                            'FADER ' + (this.props.faderIndex + 1)}
+                        {this.props.label}
                         <button
                             className="close"
                             onClick={() => this.handleClose()}
@@ -845,7 +837,7 @@ const mapStateToProps = (state: any, props: any): IChanStripFullInjectProps => {
     }
     if (props.faderIndex >= 0) {
         inject = {
-            label: state.faders[0].fader[props.faderIndex].label,
+            label: getFaderLabel(props.faderIndex, 'FADER'),
             selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
             numberOfChannelsInType:
                 state.settings[0].mixers[0].numberOfChannelsInType,

--- a/client/components/Channel.tsx
+++ b/client/components/Channel.tsx
@@ -24,6 +24,7 @@ import { storeShowChanStrip } from '../../server/reducers/settingsActions'
 import { withTranslation } from 'react-i18next'
 import { VuLabelConversionType } from '../../server/constants/MixerProtocolInterface'
 import { Conversions } from '../../server/utils/dbConversion'
+import { getFaderLabel } from '../utils/labels'
 
 interface IChannelInjectProps {
     t: any
@@ -31,6 +32,7 @@ interface IChannelInjectProps {
     settings: ISettings
     channelType: number
     channelTypeIndex: number
+    label: string
 }
 
 interface IChannelProps {
@@ -65,7 +67,7 @@ class Channel extends React.Component<
                 this.props.fader.ignoreAutomation ||
             nextProps.fader.showChannel != this.props.fader.showChannel ||
             nextProps.fader.faderLevel != this.props.fader.faderLevel ||
-            nextProps.fader.label != this.props.fader.label ||
+            nextProps.label != this.props.label ||
             nextProps.settings.mixers[0].mixerProtocol !=
                 this.props.settings.mixers[0].mixerProtocol ||
             nextProps.settings.showPfl != this.props.settings.showPfl ||
@@ -251,9 +253,7 @@ class Channel extends React.Component<
                     this.handlePgm()
                 }}
             >
-                {this.props.fader.label != ''
-                    ? this.props.fader.label
-                    : 'CH ' + (this.faderIndex + 1)}
+                {this.props.label}
             </button>
         )
     }
@@ -315,9 +315,7 @@ class Channel extends React.Component<
                     this.handleShowChanStrip()
                 }}
             >
-                {this.props.fader.label != ''
-                    ? this.props.fader.label
-                    : 'CH ' + (this.faderIndex + 1)}
+                {this.props.label}
             </button>
         )
     }
@@ -462,6 +460,7 @@ const mapStateToProps = (state: any, props: any): IChannelInjectProps => {
         channelType: 0 /* TODO: state.channels[0].channel[props.channelIndex].channelType, */,
         channelTypeIndex:
             props.faderIndex /* TODO: state.channels[0].channel[props.channelIndex].channelTypeIndex, */,
+        label: getFaderLabel(props.faderIndex)
     }
 }
 

--- a/client/components/ChannelMonitorOptions.tsx
+++ b/client/components/ChannelMonitorOptions.tsx
@@ -11,6 +11,7 @@ import {
     SOCKET_SET_FADER_MONITOR,
     SOCKET_SHOW_IN_MINI_MONITOR,
 } from '../../server/constants/SOCKET_IO_DISPATCHERS'
+import { getFaderLabel } from '../utils/labels'
 
 interface IMonitorSettingsInjectProps {
     label: string
@@ -119,7 +120,7 @@ class ChannelMonitorOptions extends React.PureComponent<
         return (
             <div className="channel-monitor-body">
                 <h2>MONITOR ROUTE</h2>
-                <h2>{this.props.label || 'FADER ' + (this.faderIndex + 1)}</h2>
+                <h2>{this.props.label}</h2>
                 <button className="close" onClick={() => this.handleClose()}>
                     X
                 </button>
@@ -195,7 +196,7 @@ const mapStateToProps = (
     props: any
 ): IMonitorSettingsInjectProps => {
     return {
-        label: state.faders[0].fader[props.faderIndex].label,
+        label: getFaderLabel(props.faderIndex, 'FADER'),
         selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
         numberOfChannelsInType: state.settings[0].mixers[0].numberOfChannelsInType,
         channel: state.channels[0].chMixerConnection[0].channel,

--- a/client/components/ChannelRouteSettings.tsx
+++ b/client/components/ChannelRouteSettings.tsx
@@ -8,6 +8,7 @@ import { storeShowOptions } from '../../server/reducers/settingsActions'
 import { SOCKET_SET_ASSIGNED_FADER } from '../../server/constants/SOCKET_IO_DISPATCHERS'
 import { IChannel, IchMixerConnection } from '../../server/reducers/channelsReducer'
 import { IFader } from '../../server/reducers/fadersReducer'
+import { getFaderLabel } from '../utils/labels'
 
 interface IChannelSettingsInjectProps {
     label: string
@@ -154,7 +155,7 @@ class ChannelRouteSettings extends React.PureComponent<
     render() {
         return (
             <div className="channel-route-body">
-                <h2>{this.props.label || 'FADER ' + (this.faderIndex + 1)}</h2>
+                <h2>{this.props.label}</h2>
                 <button className="close" onClick={() => this.handleClose()}>
                     X
                 </button>
@@ -185,7 +186,7 @@ const mapStateToProps = (
     props: any
 ): IChannelSettingsInjectProps => {
     return {
-        label: state.faders[0].fader[props.faderIndex].label,
+        label: getFaderLabel(props.faderIndex, 'FADER'),
         chMixerConnections: state.channels[0].chMixerConnection,
         fader: state.faders[0].fader,
     }

--- a/client/components/Channels.tsx
+++ b/client/components/Channels.tsx
@@ -7,6 +7,7 @@ import '../assets/css/Channels.css'
 import { Store } from 'redux'
 import {
     storeSetPage,
+    storeShowLabelSetup,
     storeShowPagesSetup,
     storeShowSettings,
     storeShowStorage,
@@ -97,6 +98,10 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
 
     handleShowPagesSetting() {
         this.props.dispatch(storeShowPagesSetup())
+    }
+
+    handleShowLabelSetting() {
+        this.props.dispatch(storeShowLabelSetup())
     }
 
     handlePages(type: PageType, i: number | string) {
@@ -300,6 +305,17 @@ class Channels extends React.Component<IChannelsInjectProps & Store> {
                                 }}
                             >
                                 PAGES SETUP
+                            </button>
+                        ) : null}
+
+                        {window.location.search.includes('settings=1') ? (
+                            <button
+                                className="button half channels-show-settings-button"
+                                onClick={() => {
+                                    this.handleShowLabelSetting()
+                                }}
+                            >
+                                LABELS
                             </button>
                         ) : null}
                     </div>

--- a/client/components/Labels.tsx
+++ b/client/components/Labels.tsx
@@ -1,0 +1,162 @@
+import React, { ChangeEvent } from 'react'
+import ClassNames from 'classnames'
+
+import '../assets/css/LabelSettings.css'
+import { Store } from 'redux'
+import { connect } from 'react-redux'
+import {
+    storeShowLabelSetup,
+    storeUpdatePagesList,
+} from '../../server/reducers/settingsActions'
+import { IFader } from '../../server/reducers/fadersReducer'
+import {
+    SOCKET_FLUSH_LABELS,
+    SOCKET_SET_LABELS,
+    SOCKET_SET_PAGES_LIST,
+} from '../../server/constants/SOCKET_IO_DISPATCHERS'
+import { ICustomPages } from '../../server/reducers/settingsReducer'
+import { getChannelLabel } from '../utils/labels'
+import { flushExtLabels, updateLabels } from '../../server/reducers/faderActions'
+import { storeFlushChLabels } from '../../server/reducers/channelActions'
+
+interface ILabelSettingsInjectProps {
+    customPages: ICustomPages[]
+    fader: IFader[]
+}
+
+class LabelSettings extends React.PureComponent<
+    ILabelSettingsInjectProps & Store
+> {
+    state = {
+        mutations: {} as Record<string, string>
+    }
+
+    constructor(props: any) {
+        super(props)
+    }
+
+    componentDidMount() {
+        this.setState({ label: this.props.customPages[0].label })
+    }
+
+    handleLabel = (event: ChangeEvent<HTMLInputElement>, index: number) => {
+        console.log(event.target.value, index)
+        this.setState({ mutations: { ...this.state.mutations, [index]: event.target.value }})
+    }
+
+    handleClearLabels() {
+        if (window.confirm('Clear all user defined labels?')) {
+            const faders = this.props.fader
+                .map((f, i) => ({ label: f.userLabel, i }))
+                .filter(f => f.label)
+                .reduce((a, b) => ({ ...a, [b.i]: '' }), {} as Record<string, string>)
+                
+            this.props.dispatch(updateLabels(faders))
+            this.props.dispatch(storeShowLabelSetup())
+            window.socketIoClient.emit(SOCKET_SET_LABELS, { update: faders })
+        }
+    }
+
+    handleFlushLabels() {
+        if (window.confirm('Flush all external (automation and channel) labels?')) {
+            this.props.dispatch(flushExtLabels())
+            this.props.dispatch(storeFlushChLabels())
+            window.socketIoClient.emit(SOCKET_FLUSH_LABELS)
+        }
+    }
+
+    handleClose = () => {
+        // window.socketIoClient.emit(SOCKET_GET_PAGES_LIST)
+        this.props.dispatch(storeShowLabelSetup())
+    }
+
+    handleCancel = () => {
+        // window.socketIoClient.emit(SOCKET_GET_PAGES_LIST)
+        this.props.dispatch(storeShowLabelSetup())
+    }
+
+    handleSave = () => {
+        this.props.dispatch(updateLabels(this.state.mutations))
+        this.props.dispatch(storeShowLabelSetup())
+        window.socketIoClient.emit(SOCKET_SET_LABELS, { update: this.state.mutations })
+    }
+
+    renderLabelList() {
+        return (
+            <div>
+                {this.props.fader.map((fader: IFader, index: number) => {
+                    const faderLabel = fader.label || '-'
+                    const channelLabel = getChannelLabel(window.reduxState, index) || '-'
+                    const mutated = this.state.mutations[index]
+                    
+                    return (
+                        <React.Fragment>
+                            <label className="settings-input-field">
+                                {`Fader ${index + 1} (${faderLabel}/${channelLabel}) : `}
+                                <input
+                                    name="fadeTime"
+                                    type="text"
+                                    value={mutated ?? fader.userLabel}
+                                    onChange={(ev) => this.handleLabel(ev, index)}
+                                />
+                            </label>
+                            <br />
+                        </React.Fragment>
+                    )
+                })}
+            </div>
+        )
+    }
+
+    render() {
+        return (
+            <div className="label-settings-body">
+                <h2>CUSTOM LABELS</h2>
+                <button className="close" onClick={() => this.handleClose()}>
+                    X
+                </button>
+                {this.renderLabelList()}
+                <button
+                    className="button"
+                    onClick={() => this.handleFlushLabels()}
+                >
+                    FLUSH EXTERNAL
+                </button>
+                <button
+                    className="button"
+                    onClick={() => this.handleClearLabels()}
+                >
+                    CLEAR ALL
+                </button>
+                <br />
+                <button
+                    className="settings-cancel-button"
+                    onClick={() => {
+                        this.handleCancel()
+                    }}
+                >
+                    CANCEL
+                </button>
+                <button
+                    className="settings-save-button"
+                    onClick={() => {
+                        this.handleSave()
+                    }}
+                >
+                    SAVE LABELS
+                </button>
+            </div>
+        )
+    }
+}
+
+const mapStateToProps = (state: any, props: any): ILabelSettingsInjectProps => {
+    return {
+        customPages: state.settings[0].customPages,
+        fader: state.faders[0].fader,
+    }
+}
+
+export default connect<any, ILabelSettingsInjectProps>(mapStateToProps)(
+    LabelSettings
+) as any

--- a/client/components/MiniChanStrip.tsx
+++ b/client/components/MiniChanStrip.tsx
@@ -6,6 +6,7 @@ import { Store } from 'redux'
 import { connect } from 'react-redux'
 import { IFader } from '../../server/reducers/fadersReducer'
 import { SOCKET_SET_AUX_LEVEL } from '../../server/constants/SOCKET_IO_DISPATCHERS'
+import { getFaderLabel } from '../utils/labels'
 
 interface IChanStripInjectProps {
     label: string
@@ -39,14 +40,7 @@ class MiniChanStrip extends React.PureComponent<
     monitor(channelIndex: number) {
         let faderIndex = this.props.channel[channelIndex].assignedFader
         if (faderIndex === -1) return null
-        let monitorName = this.props.fader[faderIndex]
-            ? this.props.fader[faderIndex].label
-            : ''
-        if (monitorName === '') {
-            monitorName =
-                'Fader ' +
-                String(this.props.channel[channelIndex].assignedFader + 1)
-        }
+        let monitorName = getFaderLabel(faderIndex, 'Fader')
         return (
             <li key={channelIndex}>
                 {monitorName}
@@ -115,7 +109,7 @@ const mapStateToProps = (state: any, props: any): IChanStripInjectProps => {
     }
     if (props.faderIndex >= 0) {
         inject = {
-            label: state.faders[0].fader[props.faderIndex].label,
+            label: getFaderLabel(props.faderIndex),
             selectedProtocol: state.settings[0].mixers[0].mixerProtocol,
             numberOfChannelsInType:
                 state.settings[0].mixers[0].numberOfChannelsInType,

--- a/client/components/MiniChannel.tsx
+++ b/client/components/MiniChannel.tsx
@@ -10,6 +10,7 @@ import { IFader } from '../../server/reducers/fadersReducer'
 import { IChannels } from '../../server/reducers/channelsReducer'
 import { ISettings } from '../../server/reducers/settingsReducer'
 import { storeShowChanStrip } from '../../server/reducers/settingsActions'
+import { getFaderLabel } from '../utils/labels'
 
 interface IChannelInjectProps {
     channels: IChannels
@@ -17,6 +18,7 @@ interface IChannelInjectProps {
     settings: ISettings
     channelType: number
     channelTypeIndex: number
+    label: string
 }
 
 interface IChannelProps {
@@ -36,7 +38,7 @@ class MiniChannel extends React.Component<
     public shouldComponentUpdate(nextProps: IChannelInjectProps) {
         return (
             nextProps.fader.showChannel != this.props.fader.showChannel ||
-            nextProps.fader.label != this.props.fader.label ||
+            nextProps.label != this.props.label ||
             nextProps.settings.showChanStrip !=
                 this.props.settings.showChanStrip
         )
@@ -58,12 +60,7 @@ class MiniChannel extends React.Component<
                     this.handleShowChanStrip()
                 }}
             >
-                {this.props.fader.label != ''
-                    ? this.props.fader.label
-                    : window.mixerProtocol.channelTypes[this.props.channelType]
-                          .channelTypeName +
-                      ' ' +
-                      (this.props.channelTypeIndex + 1)}
+                {this.props.label}
             </button>
         )
     }
@@ -88,6 +85,7 @@ const mapStateToProps = (state: any, props: any): IChannelInjectProps => {
         channelType: 0 /* TODO: state.channels[0].channel[props.channelIndex].channelType, */,
         channelTypeIndex:
             props.faderIndex /* TODO: state.channels[0].chMixerConnection[0].channel[props.channelIndex].channelTypeIndex, */,
+        label: getFaderLabel(props.faderIndex)
     }
 }
 

--- a/client/components/PagesSettings.tsx
+++ b/client/components/PagesSettings.tsx
@@ -15,6 +15,7 @@ import {
     SOCKET_SET_PAGES_LIST,
 } from '../../server/constants/SOCKET_IO_DISPATCHERS'
 import { ICustomPages } from '../../server/reducers/settingsReducer'
+import { getFaderLabel } from '../utils/labels'
 
 //Set style for Select dropdown component:
 const selectorColorStyles = {
@@ -146,7 +147,7 @@ class PagesSettings extends React.PureComponent<
                                 ].faders.includes(index),
                             })}
                         >
-                            {' Fader ' + (index + 1) + ' - ' + fader.label + ' : '}
+                            {' Fader ' + (index + 1) + ' - ' + getFaderLabel(index) + ' : '}
                             {}
                             <input
                                 type="checkbox"

--- a/client/components/Settings.tsx
+++ b/client/components/Settings.tsx
@@ -92,10 +92,10 @@ class Settings extends React.PureComponent<IAppProps & Store, IState> {
         this.setState({ settings: settingsCopy })
     }
 
-    handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
         let settingsCopy = Object.assign({}, this.state.settings)
         if (event.target.type === 'checkbox') {
-            ;(settingsCopy as any)[event.target.name] = !!event.target.checked
+            ;(settingsCopy as any)[event.target.name] = !!(event.target as HTMLInputElement).checked
         } else {
             ;(settingsCopy as any)[event.target.name] = event.target.value
         }
@@ -461,6 +461,20 @@ class Settings extends React.PureComponent<IAppProps & Store, IState> {
                         value={this.state.settings.numberOfMixers}
                         onChange={this.handleNumberOfMixers}
                     />
+                </label>
+                <br />
+                <label className="settings-input-field">
+                    LABEL TYPE :
+                    <select
+                        name="labelType"
+                        value={this.state.settings.labelType}
+                        onChange={this.handleChange}
+                    >
+                        <option value="automatic">Automatic</option>
+                        <option value="user">User labels</option>
+                        <option value="automation">Automation labels</option>
+                        <option value="channel">Channel labels</option>
+                    </select>
                 </label>
                 <br />
                 <label className="settings-input-field">

--- a/client/utils/labels.ts
+++ b/client/utils/labels.ts
@@ -1,0 +1,47 @@
+import { IStore } from '../../server/reducers/indexReducer'
+
+export function getChannelLabel(
+    state: IStore,
+    faderIndex: number
+): string | undefined {
+    return state.channels[0].chMixerConnection
+        .flatMap((conn) =>
+            conn.channel.map((ch) => ({
+                assignedFader: ch.assignedFader,
+                label: ch.label,
+            }))
+        )
+        .filter((ch) => ch.label && ch.label !== '')
+        .find((ch) => ch.assignedFader === faderIndex)?.label
+}
+
+export function getFaderLabel(faderIndex: number, defaultName = 'CH'): string {
+    const state: IStore = window.reduxState
+    const automationLabel =
+        state.faders[0].fader[faderIndex] &&
+        state.faders[0].fader[faderIndex].label !== ''
+            ? state.faders[0].fader[faderIndex].label
+            : undefined
+    const userLabel =
+        state.faders[0].fader[faderIndex] &&
+        state.faders[0].fader[faderIndex].userLabel !== ''
+            ? state.faders[0].fader[faderIndex].userLabel
+            : undefined
+    const channelLabel = getChannelLabel(state, faderIndex)
+
+    switch (state.settings[0].labelType) {
+        case 'automatic':
+            return (
+                userLabel ||
+                automationLabel ||
+                channelLabel ||
+                defaultName + ' ' + (faderIndex + 1)
+            )
+        case 'automation':
+            return automationLabel || defaultName + ' ' + (faderIndex + 1)
+        case 'user':
+            return userLabel || defaultName + ' ' + (faderIndex + 1)
+        case 'channel':
+            return channelLabel || defaultName + ' ' + (faderIndex + 1)
+    }
+}

--- a/server/MainThreadHandler.ts
+++ b/server/MainThreadHandler.ts
@@ -58,6 +58,9 @@ import {
     SOCKET_TOGGLE_ALL_MANUAL,
     SOCKET_SET_PAGES_LIST,
     SOCKET_SET_MIXER_ONLINE,
+    SOCKET_SET_LABELS,
+    SOCKET_GET_LABELS,
+    SOCKET_FLUSH_LABELS,
 } from './constants/SOCKET_IO_DISPATCHERS'
 import {
     storeFaderLevel,
@@ -78,8 +81,11 @@ import {
     storeInputSelector,
     removeAllAssignedChannels,
     storeSetAssignedChannel,
+    updateLabels,
+    flushExtLabels,
 } from './reducers/faderActions'
 import {
+    storeFlushChLabels,
     storeSetAssignedFader,
     storeSetAuxLevel,
 } from './reducers/channelActions'
@@ -455,6 +461,19 @@ export class MainThreadHandlers {
                 logger.verbose('Toggle manual mode for all')
                 store.dispatch(storeAllManual())
                 this.updateFullClientStore()
+            })
+            .on(SOCKET_SET_LABELS, (payload: any) => {
+                store.dispatch(updateLabels(payload.update))
+            })
+            .on(SOCKET_GET_LABELS, () => {
+                socketServer.emit(
+                    SOCKET_GET_LABELS,
+                    state.faders[0].fader.map((f) => f.userLabel)
+                )
+            })
+            .on(SOCKET_FLUSH_LABELS, () => {
+                store.dispatch(flushExtLabels())
+                store.dispatch(storeFlushChLabels())
             })
     }
 }

--- a/server/constants/SOCKET_IO_DISPATCHERS.ts
+++ b/server/constants/SOCKET_IO_DISPATCHERS.ts
@@ -36,6 +36,7 @@ export const SOCKET_SAVE_CCG_FILE = 'saveCcgFile'
 export const SOCKET_GET_PAGES_LIST = 'getPagesList'
 export const SOCKET_RETURN_PAGES_LIST = 'getPagesList'
 export const SOCKET_TOGGLE_ALL_MANUAL = 'toggleAllManual'
+export const SOCKET_GET_LABELS = 'getLabels'
 
 // Store updates:
 export const SOCKET_SET_FULL_STORE = 'setFullStore'
@@ -43,3 +44,5 @@ export const SOCKET_SET_STORE_FADER = 'setStoreFader'
 export const SOCKET_SET_STORE_CHANNEL = 'setStoreChannel'
 export const SOCKET_SET_MIXER_ONLINE = 'setStoreSettings'
 export const SOCKET_SET_PAGES_LIST = 'setPagesList'
+export const SOCKET_SET_LABELS = 'setLabels'
+export const SOCKET_FLUSH_LABELS = 'flushLabels'

--- a/server/reducers/channelActions.ts
+++ b/server/reducers/channelActions.ts
@@ -7,6 +7,8 @@ export const SET_SINGLE_CH_STATE = 'SET_SINGLE_CH_STATE'
 export const FADE_ACTIVE = 'FADE_ACTIVE'
 export const SET_ASSIGNED_FADER = 'SET_ASSIGNED_FADER'
 export const SET_PRIVATE = 'SET_PRIVATE'
+export const SET_CHANNEL_LABEL = 'SET_CHANNEL_LABEL'
+export const FLUSH_CHANNEL_LABELS = 'FLUSH_CHANNEL_LABELS'
 
 export const storeSetOutputLevel = (
     mixerIndex: number,
@@ -90,5 +92,24 @@ export const storeSetChPrivate = (channel: number, tag: string, value: any) => {
         channel: channel,
         tag: tag,
         value: value,
+    }
+}
+
+export const storeSetChLabel = (
+    mixerIndex: number,
+    channel: number,
+    label: string
+) => {
+    return {
+        type: SET_CHANNEL_LABEL,
+        mixerIndex: mixerIndex,
+        channel: channel,
+        label: label,
+    }
+}
+
+export const storeFlushChLabels = () => {
+    return {
+        type: FLUSH_CHANNEL_LABELS,
     }
 }

--- a/server/reducers/channelsReducer.ts
+++ b/server/reducers/channelsReducer.ts
@@ -6,6 +6,8 @@ import {
     FADE_ACTIVE,
     SET_AUX_LEVEL,
     SET_SINGLE_CH_STATE,
+    SET_CHANNEL_LABEL,
+    FLUSH_CHANNEL_LABELS,
 } from './channelActions'
 
 export interface IChannels {
@@ -20,6 +22,7 @@ export interface IChannel {
     channelType: number
     channelTypeIndex: number
     assignedFader: number
+    label?: string
     fadeActive: boolean
     outputLevel: number
     auxLevel: number[]
@@ -132,16 +135,29 @@ export const channels = (
             return nextState
         case SET_PRIVATE:
             if (
-                !nextState[0].chMixerConnection[0].channel[action.channel]
-                    .private
+                !nextState[0].chMixerConnection[action.mixerIndex].channel[
+                    action.channel
+                ].private
             ) {
-                nextState[0].chMixerConnection[0].channel[
+                nextState[0].chMixerConnection[action.mixerIndex].channel[
                     action.channel
                 ].private = {}
             }
-            nextState[0].chMixerConnection[0].channel[action.channel].private![
-                action.tag
-            ] = action.value
+            nextState[0].chMixerConnection[action.mixerIndex].channel[
+                action.channel
+            ].private![action.tag] = action.value
+            return nextState
+        case SET_CHANNEL_LABEL:
+            nextState[0].chMixerConnection[action.mixerIndex].channel[
+                action.channel
+            ].label = action.label
+            return nextState
+        case FLUSH_CHANNEL_LABELS:
+            for (const mixer of nextState[0].chMixerConnection) {
+                for (const ch of mixer.channel) {
+                    ch.label = undefined
+                }
+            }
             return nextState
         default:
             return nextState

--- a/server/reducers/faderActions.ts
+++ b/server/reducers/faderActions.ts
@@ -7,7 +7,8 @@ export const SET_SINGLE_FADER_STATE = 'SET_SINGLE_FADER_STATE'
 export const SET_FADER_LEVEL = 'SET_FADER_LEVEL'
 export const SET_INPUT_GAIN = 'SET_INPUT_GAIN'
 export const SET_INPUT_SELECTOR = 'SET_INPUT_SELECTOR'
-export const SET_CHANNEL_LABEL = 'SET_CHANNEL_LABEL'
+export const SET_FADER_LABEL = 'SET_FADER_LABEL'
+export const SET_USER_LABEL = 'SET_USER_LABEL'
 export const SET_FADER_FX = 'SET_FADER_FX'
 export const SET_FADER_MONITOR = 'SET_FADER_MONITOR'
 export const SET_ASSIGNED_CHANNEL = 'SET_ASSIGNED_CHANNEL'
@@ -30,6 +31,8 @@ export const X_MIX = 'X_MIX'
 export const NEXT_MIX = 'NEXT_MIX'
 export const FADE_TO_BLACK = 'FADE_TO_BLACK'
 
+export const UPDATE_LABEL_LIST = 'UPDATE_LABEL_LIST'
+export const FLUSH_FADER_LABELS = 'FLUSH_FADER_LABELS'
 export const CLEAR_PST = 'CLEAR_PST'
 export const SNAP_RECALL = 'SNAP_RECALL'
 export const SET_CHANNEL_DISABLED = 'SET_CHANNEL_DISABLED'
@@ -91,7 +94,15 @@ export const storeInputSelector = (faderIndex: number, selected: number) => {
 
 export const storeFaderLabel = (faderIndex: number, label: string) => {
     return {
-        type: SET_CHANNEL_LABEL,
+        type: SET_FADER_LABEL,
+        faderIndex: faderIndex,
+        label: label,
+    }
+}
+
+export const storeUserLabel = (faderIndex: number, label: string) => {
+    return {
+        type: SET_USER_LABEL,
         faderIndex: faderIndex,
         label: label,
     }
@@ -311,5 +322,18 @@ export const storeCapability = (
 export const storeAllManual = () => {
     return {
         type: TOGGLE_ALL_MANUAL,
+    }
+}
+
+export const updateLabels = (update: Record<number, string>) => {
+    return {
+        type: UPDATE_LABEL_LIST,
+        update,
+    }
+}
+
+export const flushExtLabels = () => {
+    return {
+        type: FLUSH_FADER_LABELS,
     }
 }

--- a/server/reducers/fadersReducer.ts
+++ b/server/reducers/fadersReducer.ts
@@ -2,7 +2,7 @@ import {
     CLEAR_PST,
     FADE_TO_BLACK,
     NEXT_MIX,
-    SET_CHANNEL_LABEL,
+    SET_FADER_LABEL,
     SET_COMPLETE_FADER_STATE,
     SET_FADER_LEVEL,
     SET_INPUT_GAIN,
@@ -33,6 +33,8 @@ import {
     TOGGLE_ALL_MANUAL,
     SET_ASSIGNED_CHANNEL,
     REMOVE_ALL_ASSIGNED_CHANNELS,
+    UPDATE_LABEL_LIST,
+    FLUSH_FADER_LABELS,
 } from './faderActions'
 
 export interface IFaders {
@@ -50,6 +52,7 @@ export interface IFader {
     inputGain: number
     inputSelector: number
     label: string
+    userLabel?: string
     pgmOn: boolean
     voOn: boolean
     pstOn: boolean
@@ -186,7 +189,7 @@ export const faders = (
         case SET_FADER_MONITOR:
             nextState[0].fader[action.faderIndex].monitor = action.auxIndex
             return nextState
-        case SET_CHANNEL_LABEL:
+        case SET_FADER_LABEL:
             if (!nextState[0].fader[action.faderIndex]) return nextState
             nextState[0].fader[action.faderIndex].label = action.label
             return nextState
@@ -374,6 +377,21 @@ export const faders = (
                 nextState[0].fader.forEach((f) => {
                     f.ignoreAutomation = true
                 })
+            }
+            return nextState
+        case UPDATE_LABEL_LIST:
+            console.log('update labels', action.update)
+            Object.entries(action.update).forEach(
+                ([index, label]: [string, string]) => {
+                    nextState[0].fader[Number(index)].userLabel =
+                        label === '' ? undefined : label
+                    console.log(index, label)
+                }
+            )
+            return nextState
+        case FLUSH_FADER_LABELS:
+            for (const fader of nextState[0].fader) {
+                fader.label = undefined
             }
             return nextState
         default:

--- a/server/reducers/settingsActions.ts
+++ b/server/reducers/settingsActions.ts
@@ -2,6 +2,7 @@ import { ICustomPages, PageType } from './settingsReducer'
 
 export const TOGGLE_SHOW_SETTINGS = 'TOGGLE_SHOW_SETTINGS'
 export const TOGGLE_SHOW_PAGES_SETUP = 'TOGGLE_SHOW_PAGES_SETUP'
+export const TOGGLE_SHOW_LABEL_SETTINGS = 'TOGGLE_SHOW_LABEL_SETTINGS'
 export const TOGGLE_SHOW_CHAN_STRIP = 'TOGGLE_SHOW_CHAN_STRIP'
 export const TOGGLE_SHOW_CHAN_STRIP_FULL = 'TOGGLE_SHOW_CHAN_STRIP_FULL'
 export const TOGGLE_SHOW_OPTION = 'TOGGLE_SHOW_OPTION'
@@ -21,6 +22,11 @@ export const storeShowSettings = () => {
 export const storeShowPagesSetup = () => {
     return {
         type: TOGGLE_SHOW_PAGES_SETUP,
+    }
+}
+export const storeShowLabelSetup = () => {
+    return {
+        type: TOGGLE_SHOW_LABEL_SETTINGS,
     }
 }
 export const storeShowChanStrip = (faderIndex: number) => {

--- a/server/reducers/settingsReducer.ts
+++ b/server/reducers/settingsReducer.ts
@@ -12,6 +12,7 @@ import {
     TOGGLE_SHOW_PAGES_SETUP,
     SET_PAGES_LIST,
     TOGGLE_SHOW_CHAN_STRIP_FULL,
+    TOGGLE_SHOW_LABEL_SETTINGS,
 } from '../reducers/settingsActions'
 
 export enum PageType {
@@ -26,6 +27,7 @@ export interface ISettings {
     /** UI state (non persistant) */
     showSettings: boolean
     showPagesSetup: boolean
+    showLabelSettings: boolean
     showChanStrip: number
     showChanStripFull: number
     showOptions: number | false
@@ -55,6 +57,7 @@ export interface ISettings {
     enablePages: boolean
     numberOfCustomPages: number
     chanStripFollowsPFL: boolean
+    labelType: 'automatic' | 'user' | 'automation' | 'channel'
 
     /** Connection state */
     serverOnline: boolean
@@ -85,6 +88,7 @@ const defaultSettingsReducerState: Array<ISettings> = [
     {
         showSettings: false,
         showPagesSetup: false,
+        showLabelSettings: false,
         showChanStrip: -1,
         showChanStripFull: -1,
         showOptions: false,
@@ -124,6 +128,7 @@ const defaultSettingsReducerState: Array<ISettings> = [
         numberOfCustomPages: 4,
         chanStripFollowsPFL: true,
         serverOnline: true,
+        labelType: 'automatic',
     },
 ]
 
@@ -139,6 +144,9 @@ export const settings = (
             return nextState
         case TOGGLE_SHOW_PAGES_SETUP:
             nextState[0].showPagesSetup = !nextState[0].showPagesSetup
+            return nextState
+        case TOGGLE_SHOW_LABEL_SETTINGS:
+            nextState[0].showLabelSettings = !nextState[0].showLabelSettings
             return nextState
         case TOGGLE_SHOW_CHAN_STRIP:
             if (nextState[0].showChanStrip !== action.channel) {

--- a/server/utils/mixerConnections/CasparCGConnection.ts
+++ b/server/utils/mixerConnections/CasparCGConnection.ts
@@ -14,8 +14,10 @@ import {
     fxParamsList,
 } from '../../constants/MixerProtocolInterface'
 import { IChannel } from '../../reducers/channelsReducer'
-import { storeSetChPrivate } from '../../reducers/channelActions'
-import { storeFaderLabel } from '../../reducers/faderActions'
+import {
+    storeSetChLabel,
+    storeSetChPrivate,
+} from '../../reducers/channelActions'
 import { logger } from '../logger'
 import { dbToFloat, floatToDB } from './LawoRubyConnection'
 import { IFader } from '../../reducers/fadersReducer'
@@ -239,7 +241,9 @@ export class CasparCGConnection {
         // Set source labels from geometry definition
         if (this.mixerProtocol.channelLabels) {
             this.mixerProtocol.channelLabels.forEach((label, channelIndex) => {
-                store.dispatch(storeFaderLabel(channelIndex, label))
+                store.dispatch(
+                    storeSetChLabel(this.mixerIndex, channelIndex, label)
+                )
             })
         }
     }

--- a/server/utils/mixerConnections/EmberMixerConnection.ts
+++ b/server/utils/mixerConnections/EmberMixerConnection.ts
@@ -12,7 +12,6 @@ import {
 import {
     storeFaderLevel,
     storeInputGain,
-    storeFaderLabel,
     storeSetPgm,
     storeSetPfl,
     storeShowChannel,
@@ -23,7 +22,10 @@ import {
 import { logger } from '../logger'
 import { LawoMC2 } from '../../constants/mixerProtocols/LawoMC2'
 import { dbToFloat, floatToDB } from './LawoRubyConnection'
-import { SET_OUTPUT_LEVEL } from '../../reducers/channelActions'
+import {
+    SET_OUTPUT_LEVEL,
+    storeSetChLabel,
+} from '../../reducers/channelActions'
 import { storeSetMixerOnline } from '../../reducers/settingsActions'
 
 export class EmberMixerConnection {
@@ -329,8 +331,9 @@ export class EmberMixerConnection {
                         `Receiving Label from Ch "${ch}", val: ${node.contents.description}`
                     )
                     store.dispatch(
-                        storeFaderLabel(
-                            channel.assignedFader,
+                        storeSetChLabel(
+                            this.mixerIndex,
+                            channelTypeIndex,
                             node.contents.description
                         )
                     )
@@ -341,8 +344,9 @@ export class EmberMixerConnection {
                         }`
                     )
                     store.dispatch(
-                        storeFaderLabel(
-                            channel.assignedFader,
+                        storeSetChLabel(
+                            this.mixerIndex,
+                            channelTypeIndex,
                             String((node.contents as Model.Parameter).value)
                         )
                     )

--- a/server/utils/mixerConnections/LawoRubyConnection.ts
+++ b/server/utils/mixerConnections/LawoRubyConnection.ts
@@ -11,7 +11,6 @@ import {
     SET_INPUT_SELECTOR,
     storeFaderLevel,
     storeInputGain,
-    storeFaderLabel,
     storeChannelDisabled,
     storeSetAMix,
     storeCapability,
@@ -19,6 +18,7 @@ import {
 } from '../../reducers/faderActions'
 import { logger } from '../logger'
 import { storeSetMixerOnline } from '../../reducers/settingsActions'
+import { storeSetChLabel } from '../../reducers/channelActions'
 
 // TODO - should these be util functions?
 export function floatToDB(f: number): number {
@@ -156,7 +156,8 @@ export class LawoRubyMixerConnection {
                     if (this.faders[channelTypeIndex + 1]) {
                         // enable
                         store.dispatch(
-                            storeFaderLabel(
+                            storeSetChLabel(
+                                this.mixerIndex,
                                 channelTypeIndex,
                                 this.faders[channelTypeIndex + 1]
                             )
@@ -170,7 +171,13 @@ export class LawoRubyMixerConnection {
                         store.dispatch(
                             storeChannelDisabled(channelTypeIndex, true)
                         )
-                        store.dispatch(storeFaderLabel(channelTypeIndex, ''))
+                        store.dispatch(
+                            storeSetChLabel(
+                                this.mixerIndex,
+                                channelTypeIndex,
+                                ''
+                            )
+                        )
                         store.dispatch(
                             storeShowChannel(channelTypeIndex, false)
                         )

--- a/server/utils/mixerConnections/OscMixerConnection.ts
+++ b/server/utils/mixerConnections/OscMixerConnection.ts
@@ -18,11 +18,11 @@ import {
 import { midasMeter } from './productSpecific/midas'
 import {
     storeSetAuxLevel,
+    storeSetChLabel,
     storeSetOutputLevel,
 } from '../../reducers/channelActions'
 import {
     storeFaderLevel,
-    storeFaderLabel,
     storeFaderFx,
     storeTogglePgm,
     storeSetMute,
@@ -289,9 +289,9 @@ export class OscMixerConnection {
                 ) {
                     let ch = message.address.split('/')[this.cmdChannelIndex]
                     store.dispatch(
-                        storeFaderLabel(
-                            state.channels[0].chMixerConnection[this.mixerIndex]
-                                .channel[ch - 1].assignedFader,
+                        storeSetChLabel(
+                            this.mixerIndex,
+                            ch - 1,
                             message.args[0]
                         )
                     )

--- a/server/utils/mixerConnections/StuderMixerConnection.ts
+++ b/server/utils/mixerConnections/StuderMixerConnection.ts
@@ -8,8 +8,9 @@ import {
     fxParamsList,
     IMixerProtocol,
 } from '../../constants/MixerProtocolInterface'
-import { storeFaderLabel, storeFaderLevel } from '../../reducers/faderActions'
+import { storeFaderLevel } from '../../reducers/faderActions'
 import { logger } from '../logger'
+import { storeSetChLabel } from '../../reducers/channelActions'
 
 export class StuderMixerConnection {
     mixerProtocol: IMixerProtocol
@@ -153,7 +154,13 @@ export class StuderMixerConnection {
             )
             .then((node: any) => {
                 this.emberConnection.subscribe(node, () => {
-                    store.dispatch(storeFaderLabel(ch - 1, node.contents.value))
+                    store.dispatch(
+                        storeSetChLabel(
+                            this.mixerIndex,
+                            ch - 1,
+                            node.contents.value
+                        )
+                    )
                 })
             })
     }


### PR DESCRIPTION
This PR adds a labeling system, labels can either come from automation, the channel names on the mixer or set by the user. The user can choose which types of labels are used or leave it to automatic where Sisyfos shall use the user defined, automation or channel label.

Additionally external labels can be flushed from the system if required / convenient.

The automation connection has been refactored to reduce code repetition as well as allow the use of labels instead of channel numbers.