### PR TITLE
fix: automation label prefix only worked with 1 letter

### DIFF
--- a/client/src/utils/labels.ts
+++ b/client/src/utils/labels.ts
@@ -17,7 +17,7 @@ export function getChannelLabel(
         state.settings[0].labelControlsIgnoreAutomation &&
         label?.startsWith(state.settings[0].labelIgnorePrefix)
     ) {
-        label = label.slice(1)
+        label = label.slice(state.settings[0].labelIgnorePrefix.length)
     }
     return label
 }

--- a/server/src/MainThreadHandler.ts
+++ b/server/src/MainThreadHandler.ts
@@ -441,7 +441,7 @@ export class MainThreadHandlers {
                             const newLabel = oldLabel.startsWith(
                                 state.settings[0].labelIgnorePrefix
                             )
-                                ? oldLabel.slice(1)
+                                ? oldLabel.slice(state.settings[0].labelIgnorePrefix.length)
                                 : oldLabel
                             store.dispatch({
                                 type: ChannelActionTypes.SET_CHANNEL_LABEL,


### PR DESCRIPTION
This fix is made on behalf of TV2 NO
Fix: Automation prefix only sliced the first letter and not the length of the prefix