### PR TITLE
Bug fix: mixer can be controlled even when the PGM is off

### DIFF
--- a/server/src/utils/MixerConnection.ts
+++ b/server/src/utils/MixerConnection.ts
@@ -397,9 +397,11 @@ export class MixerGenericConnection {
         faderIndex: number,
         fadeTime: number
     ) => {
+        const isOnAir = state.faders[0].fader[faderIndex].pgmOn ||
+            state.faders[0].fader[faderIndex].voOn
+
         if (
-            !state.faders[0].fader[faderIndex].pgmOn &&
-            !state.faders[0].fader[faderIndex].voOn &&
+            !isOnAir &&
             state.channels[0].chMixerConnection[mixerIndex].channel[
                 channelIndex
             ].outputLevel === 0
@@ -429,15 +431,10 @@ export class MixerGenericConnection {
             channel: channelIndex,
             active: true,
         })
-        // If fadeTime is 0 - jump to level and don't use timer
-        if (fadeTime === 0) {
+        if (isOnAir && fadeTime === 0) {
+            // If fadeTime is 0 - jump to level and don't use timer
             this.jumpToLevel(mixerIndex, channelIndex, faderIndex)
-            return
-        }
-        if (
-            state.faders[0].fader[faderIndex].pgmOn ||
-            state.faders[0].fader[faderIndex].voOn
-        ) {
+        } else if (isOnAir) {
             this.fadeUp(mixerIndex, channelIndex, fadeTime, faderIndex)
         } else {
             this.fadeDown(mixerIndex, channelIndex, fadeTime)


### PR DESCRIPTION
Couple of things in this, most notable the change in MixerConnection.ts fixes a scenario where the channel would be off-air in sisyfos but dragging the fader would also send those values to the mixer.

Additionally some changes in the Lawo Ruby integration

- Fader now has full range, previously it was capped at -90 dB. Before, putting the fader between -90dB and -191dB would be signalled as "off air" in sisyfos even though sound could pass
- Duplicate values are now filtered out, as this would previously log timeouts when the mixer would not send back an updated value
- Besides updating the fader level we now also update the output level when we receive an update from the mixer