### PR TITLE
feat: send update to automation after changes

### DIFF
--- a/server/src/MainThreadHandler.ts
+++ b/server/src/MainThreadHandler.ts
@@ -4,6 +4,7 @@ import {
     mixerProtocolPresets,
     mixerGenericConnection,
     remoteConnections,
+    automationConnection
 } from './mainClasses'
 import { SnapshotHandler } from './utils/SnapshotHandler'
 import { socketServer } from './expressHandler'
@@ -54,6 +55,7 @@ export class MainThreadHandlers {
 
     updateFullClientStore() {
         socketServer.emit(IO.SOCKET_SET_FULL_STORE, state)
+        automationConnection.updateRemoteFullState()
     }
 
     updatePartialStore(faderIndex: number) {
@@ -73,6 +75,7 @@ export class MainThreadHandlers {
                 })
             }
         )
+        automationConnection.updateRemoteFader(faderIndex, state.faders[0].fader[faderIndex])
     }
 
     updateMixerOnline(mixerIndex: number, onLineState?: boolean) {


### PR DESCRIPTION
This PR adds sending update to connected automation clients, so they can track the state of Sisyfos

Note - it doesn't like like we'll be actively using this anytime soon but I wrote it already so it might as well be in a PR