### PR TITLE
chore: make publish-lib.yaml work after upgrading yarn

### DIFF
--- a/.github/workflows/publish-lib.yaml
+++ b/.github/workflows/publish-lib.yaml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.node-version }}
+      - name: Enable Corepack
+        run: corepack enable
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -33,7 +35,13 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Configure CodeArtifact Token
         run: |
-          echo CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.AWS_DOMAIN_NAME }}  --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --query authorizationToken --output text --region ${{ secrets.AWS_REGION }}) >> $GITHUB_ENV
+          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+            --domain ${{ secrets.AWS_CODE_ARTIFACT_DOMAIN }} \
+            --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} \
+            --region ${{ secrets.AWS_REGION }} \
+            --query authorizationToken \
+            --output text)
+          echo "CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_ENV
       - name: Check release is desired
         id: do-publish
         run: |
@@ -64,19 +72,42 @@ jobs:
           COMMIT_DATE=$(date -d @$COMMIT_TIMESTAMP +%Y%m%d-%H%M%S)
           GIT_HASH=$(git rev-parse --short HEAD)
           PRERELEASE_TAG=nightly-$(echo "${{ github.ref_name }}" | sed -r 's/[^a-z0-9]+/-/gi')
+          CURRENT_VERSION=$(node -p "require('./component-lib/package.json').version")
           cd component-lib
-          yarn version --prerelease --preid "$PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH"
+          yarn version "$CURRENT_VERSION-$PRERELEASE_TAG-$COMMIT_DATE-$GIT_HASH"
         env:
           CI: true
+
+      - name: Retrieve CodeArtifact endpoint
+        id: codeartifact
+        run: |
+            cd component-lib
+
+            echo "Fetching CodeArtifact repository endpoint..."
+            REPOSITORY_ENDPOINT=$(aws codeartifact get-repository-endpoint \
+                --domain ${{ secrets.AWS_CODE_ARTIFACT_DOMAIN }} \
+                --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} \
+                --repository ${{ secrets.AWS_CODE_ARTIFACT_REPOSITORY }} \
+                --format npm \
+                --region ${{ secrets.AWS_REGION }} \
+                --query repositoryEndpoint \
+                --output text)
+
+            echo "REPOSITORY_ENDPOINT=$REPOSITORY_ENDPOINT" >> $GITHUB_ENV
+
+      - name: Configure Yarn for AWS CodeArtifact
+        run: |
+            yarn config set npmRegistryServer "$REPOSITORY_ENDPOINT"
+            yarn config set "npmRegistries[\"$REPOSITORY_ENDPOINT\"].npmAuthToken" "$CODEARTIFACT_AUTH_TOKEN"
+            yarn config set "npmRegistries[\"$REPOSITORY_ENDPOINT\"].npmAlwaysAuth" true
+
       - name: Publish to Code Artifatct
         if: ${{ steps.do-publish.outputs.publish }}
         run: |
-          aws codeartifact login --tool npm --repository ${{ secrets.AWS_CODE_ARTIFACT_REPOSITORY }} --domain ${{ secrets.AWS_CODE_ARTIFACT_DOMAIN }} --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --region ${{ secrets.AWS_REGION }}
           NEW_VERSION=$(node -p "require('./component-lib/package.json').version")
 
-          yarn config set version-git-tag false
-          yarn config set version-tag-prefix ""
-          yarn publish component-lib --new-version "$NEW_VERSION" --tag "$NEW_VERSION"
+          cd component-lib
+          yarn npm publish --tag "$NEW_VERSION"
 
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "**Published:** $NEW_VERSION" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR fixes the publish-lib.yaml workflow, which got broken when yarn was updated to version 4.